### PR TITLE
Add Python3 compatibility changes

### DIFF
--- a/svg2tikz/inkexlib/inkex.py
+++ b/svg2tikz/inkexlib/inkex.py
@@ -84,7 +84,11 @@ def errormsg(msg):
          ...
          inkex.errormsg(_("This extension requires two selected paths."))
     """
-    sys.stderr.write((unicode(msg) + "\n").encode("UTF-8"))
+    msg = msg.decode("UTF-8") if isinstance(msg, bytes) else str(msg)
+    if hasattr(sys.stderr, "buffer"):
+        sys.stderr.buffer.write((msg + "\n").encode("UTF-8"))
+    else:
+        sys.stderr.write((msg + "\n").encode("UTF-8"))
 
 def check_inkbool(option, opt, value):
     if str(value).capitalize() == 'True':
@@ -96,7 +100,7 @@ def check_inkbool(option, opt, value):
 
 def addNS(tag, ns=None):
     val = tag
-    if ns!=None and len(ns)>0 and NSS.has_key(ns) and len(tag)>0 and tag[0]!='{':
+    if ns is not None and len(ns) > 0 and ns in NSS and len(tag) > 0 and tag[0] != '{':
         val = "{%s}%s" % (NSS[ns], tag)
     return val
 

--- a/svg2tikz/inkexlib/simplepath.py
+++ b/svg2tikz/inkexlib/simplepath.py
@@ -48,8 +48,8 @@ def lexPath(d):
             yield [d[offset:m.end()], False]
             offset = m.end()
             continue
-        #TODO: create new exception
-        raise Exception, 'Invalid path data!'
+        # TODO: create new exception
+        raise Exception('Invalid path data!')
 '''
 pathdefs = {commandfamily:
     [
@@ -87,14 +87,14 @@ def parsePath(d):
     
     while 1:
         try:
-            token, isCommand = lexer.next()
+            token, isCommand = next(lexer)
         except StopIteration:
             break
         params = []
         needParam = True
         if isCommand:
             if not lastCommand and token.upper() != 'M':
-                raise Exception, 'Invalid path, must begin with moveto.'    
+                raise Exception('Invalid path, must begin with moveto.')
             else:                
                 command = token
         else:
@@ -107,16 +107,16 @@ def parsePath(d):
                 else:
                     command = pathdefs[lastCommand.upper()][0].lower()
             else:
-                raise Exception, 'Invalid path, no initial command.'    
+                raise Exception('Invalid path, no initial command.')
         numParams = pathdefs[command.upper()][1]
         while numParams > 0:
             if needParam:
                 try: 
-                    token, isCommand = lexer.next()
+                    token, isCommand = next(lexer)
                     if isCommand:
-                        raise Exception, 'Invalid number of parameters'
+                        raise Exception('Invalid number of parameters')
                 except StopIteration:
-                    raise Exception, 'Unexpected end of path'
+                    raise Exception('Unexpected end of path')
             cast = pathdefs[command.upper()][2][-numParams]
             param = cast(token)
             if command.islower():

--- a/svg2tikz/inkexlib/simplestyle.py
+++ b/svg2tikz/inkexlib/simplestyle.py
@@ -179,7 +179,7 @@ def parseStyle(s):
       return dict([i.split(":") for i in s.split(";") if len(i)])
 def formatStyle(a):
     """Format an inline style attribute from a dictionary"""
-    return ";".join([att+":"+str(val) for att,val in a.iteritems()])
+    return ";".join([att+":"+str(val) for att,val in a.items()])
 def isColor(c):
     """Determine if its a color we can use. If not, leave it unchanged."""
     if c.startswith('#') and (len(c)==4 or len(c)==7):

--- a/tests/test_svgtestsuite.py
+++ b/tests/test_svgtestsuite.py
@@ -157,8 +157,8 @@ class SVGListTestCase(unittest.TestCase):
         for svgfile in self.svglist:
             try:
                 tikz_code = tkzex.convert_file(svgfile, crop=True, ignore_text=True, verbose=True)
-            except:
-                print "Failed to convert %s" % basename(svgfile)
+            except Exception:
+                print("Failed to convert %s" % basename(svgfile))
                 log.exception("Failed to convert %s", basename(svgfile))
                 self.failed_files.append(svgfile)
                 continue


### PR DESCRIPTION
## Summary
- tweak imports and compatibility helpers for Python3
- fix syntax issues in tikz_export module
- update helper library to avoid deprecated methods
- adjust failing tests for cross-version compatibility
- fix simplepath for Python3

## Testing
- `python -m py_compile svg2tikz/extensions/tikz_export.py svg2tikz/inkexlib/inkex.py svg2tikz/inkexlib/simplestyle.py svg2tikz/inkexlib/simplepath.py tests/test_svgtestsuite.py`
- `pytest -q` *(fails: 28 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842fe2ec338832d9927f1d9f83de976